### PR TITLE
Fix PARTICIPE E FAÇA A DIFERENÇA button navigation

### DIFF
--- a/src/components/sections/JoinCause.tsx
+++ b/src/components/sections/JoinCause.tsx
@@ -130,6 +130,7 @@ export default function JoinCause() {
             <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
               <Button
                 variant="secondary"
+                href="https://gofund.me/5eb16f31a"
                 className="!rounded-[24px] !bg-[#D7D7AA] !border-4 !border-black !px-[40px] !py-[24px] !font-fredoka font-semibold !text-[20px] md:!text-[22px] lg:!text-[24px] !leading-none !uppercase !whitespace-nowrap !text-black hover:!bg-[#D7D7AA] hover:!translate-x-1 hover:!translate-y-1 active:!translate-x-1 active:!translate-y-1 !shadow-none transition-all duration-200"
               >
                 PARTICIPE E FAÇA A DIFERENÇA!


### PR DESCRIPTION
## Summary
- Adds `href` prop to the "PARTICIPE E FAÇA A DIFERENÇA!" button in JoinCause section
- Button now navigates to the GoFundMe donation page (`https://gofund.me/5eb16f31a`)

## Test plan
- [ ] Navigate to the "Junte-se à Causa" section
- [ ] Click the "PARTICIPE E FAÇA A DIFERENÇA!" button
- [ ] Verify it opens the GoFundMe donation page

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)