### PR TITLE
Fix CONHEÇA A APP COMFY button navigation

### DIFF
--- a/src/components/sections/AppComfy.tsx
+++ b/src/components/sections/AppComfy.tsx
@@ -45,7 +45,7 @@ export default function AppComfy() {
               <DonateButton
                 text="CONHEÇA A APP COMFY"
                 showFace={false}
-                onClick={() => {}}
+                href="https://www.instagram.com/the.comfy.app/"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Replaces empty `onClick` handler with `href` prop on the "CONHEÇA A APP COMFY" button
- Button now navigates to the Comfy App Instagram page (`https://www.instagram.com/the.comfy.app/`)

## Test plan
- [x] Navigate to the "A App" section
- [x] Click the "CONHEÇA A APP COMFY" button
- [x] Verify it opens the Instagram page in a new tab

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)