### PR TITLE
Fix social media links in JoinCause section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1976,6 +1977,7 @@
       "version": "19.1.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1984,6 +1986,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2318,6 +2321,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -4628,6 +4632,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4636,6 +4641,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -4883,6 +4889,7 @@
       "version": "4.49.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
       "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5578,6 +5585,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5765,6 +5773,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/sections/JoinCause.tsx
+++ b/src/components/sections/JoinCause.tsx
@@ -149,31 +149,31 @@ export default function JoinCause() {
             <div className="h-[48px] md:h-[56px] lg:h-[64px] w-[240px] md:w-[272px] lg:w-[304px] flex items-center justify-center gap-4">
               {/* Placeholder social icons - will be replaced with actual SVG asset */}
               {/* For now, creating individual icon placeholders */}
-              <a href="#" className="w-12 h-12 md:w-14 md:h-14 lg:w-16 lg:h-16 flex items-center justify-center hover:opacity-80 transition-opacity" aria-label="Facebook">
-                <img 
+              <a href="https://www.facebook.com/associacao.moces" target="_blank" rel="noopener noreferrer" className="w-12 h-12 md:w-14 md:h-14 lg:w-16 lg:h-16 flex items-center justify-center hover:opacity-80 transition-opacity" aria-label="Facebook">
+                <img
                   src="app/facebookicon.svg"
-                  alt="Facebook" 
+                  alt="Facebook"
                   className="w-full h-full object-contain"
                 />
               </a>
-              <a href="#" className="w-12 h-12 md:w-14 md:h-14 lg:w-16 lg:h-16 flex items-center justify-center hover:opacity-80 transition-opacity" aria-label="Instagram">
-                <img 
+              <a href="https://www.instagram.com/moces.pt/" target="_blank" rel="noopener noreferrer" className="w-12 h-12 md:w-14 md:h-14 lg:w-16 lg:h-16 flex items-center justify-center hover:opacity-80 transition-opacity" aria-label="Instagram">
+                <img
                   src="app/instagramicon.svg"
-                  alt="Instagram" 
+                  alt="Instagram"
                   className="w-full h-full object-contain"
                 />
               </a>
-              <a href="#" className="w-12 h-12 md:w-14 md:h-14 lg:w-16 lg:h-16 flex items-center justify-center hover:opacity-80 transition-opacity" aria-label="LinkedIn">
-                <img 
+              <a href="https://www.linkedin.com/company/associacaomoces/" target="_blank" rel="noopener noreferrer" className="w-12 h-12 md:w-14 md:h-14 lg:w-16 lg:h-16 flex items-center justify-center hover:opacity-80 transition-opacity" aria-label="LinkedIn">
+                <img
                   src="app/linkedinicon.svg"
-                  alt="LinkedIn" 
+                  alt="LinkedIn"
                   className="w-full h-full object-contain"
                 />
               </a>
-              <a href="#" className="w-12 h-12 md:w-14 md:h-14 lg:w-16 lg:h-16 flex items-center justify-center hover:opacity-80 transition-opacity" aria-label="TikTok">
-                <img 
+              <a href="https://www.tiktok.com/@the.comfy.app" target="_blank" rel="noopener noreferrer" className="w-12 h-12 md:w-14 md:h-14 lg:w-16 lg:h-16 flex items-center justify-center hover:opacity-80 transition-opacity" aria-label="TikTok">
+                <img
                   src="app/tiktokicon.svg"
-                  alt="TikTok" 
+                  alt="TikTok"
                   className="w-full h-full object-contain"
                 />
               </a>


### PR DESCRIPTION
## Summary
- Replace placeholder `#` hrefs with actual social media URLs in the "Partilhar o projeto" section
- Facebook → https://www.facebook.com/associacao.moces
- Instagram → https://www.instagram.com/moces.pt/
- LinkedIn → https://www.linkedin.com/company/associacaomoces/
- TikTok → https://www.tiktok.com/@the.comfy.app
- Adds `target="_blank"` and `rel="noopener noreferrer"` for security

## Test plan
- [x] Build passes
- [x] Click Facebook icon → opens Facebook page in new tab
- [x] Click Instagram icon → opens Instagram page in new tab
- [x] Click LinkedIn icon → opens LinkedIn page in new tab
- [x] Click TikTok icon → opens TikTok page in new tab

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)