### PR TITLE
Add target="_blank" to "Participe e faça a diferença" button

### DIFF
--- a/src/components/sections/JoinCause.tsx
+++ b/src/components/sections/JoinCause.tsx
@@ -131,6 +131,8 @@ export default function JoinCause() {
               <Button
                 variant="secondary"
                 href="https://gofund.me/5eb16f31a"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="!rounded-[24px] !bg-[#D7D7AA] !border-4 !border-black !px-[40px] !py-[24px] !font-fredoka font-semibold !text-[20px] md:!text-[22px] lg:!text-[24px] !leading-none !uppercase !whitespace-nowrap !text-black hover:!bg-[#D7D7AA] hover:!translate-x-1 hover:!translate-y-1 active:!translate-x-1 active:!translate-y-1 !shadow-none transition-all duration-200"
               >
                 PARTICIPE E FAÇA A DIFERENÇA!

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -7,15 +7,19 @@ interface ButtonProps {
   href?: string;
   className?: string;
   type?: 'button' | 'submit' | 'reset';
+  target?: string;
+  rel?: string;
 }
 
-export default function Button({ 
-  variant = 'primary', 
-  children, 
+export default function Button({
+  variant = 'primary',
+  children,
   onClick,
   href,
   className = '',
-  type = 'button'
+  type = 'button',
+  target,
+  rel
 }: ButtonProps) {
   const baseClasses = "rounded-full px-8 py-4 font-semibold transition-all duration-300 inline-block text-center cursor-pointer";
   
@@ -28,7 +32,7 @@ export default function Button({
 
   if (href) {
     return (
-      <a href={href} className={classes}>
+      <a href={href} className={classes} target={target} rel={rel}>
         {children}
       </a>
     );


### PR DESCRIPTION
## Summary
- Added `target` and `rel` props to the Button component
- Updated the "Participe e faça a diferença" button in JoinCause section to open in a new tab

## Test plan
- [x] Verified the link has `target="_blank"` and `rel="noopener noreferrer"` attributes
- [x] Button should now open the donation page in a new tab like other external links

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)