### PR TITLE
Fix hero text overlap with flower on desktop

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -16,7 +16,7 @@ export default function Hero() {
         </div>
 
         {/* Flower collage on the right (with mask) */}
-        <div className="absolute right-0 bottom-0 w-[186px] h-[180px] md:w-[300px] md:h-[292px] lg:w-[402px] lg:h-[390px] pointer-events-none opacity-80 md:opacity-100">
+        <div className="absolute right-0 bottom-0 w-[186px] h-[180px] md:w-[300px] md:h-[292px] lg:w-[402px] lg:h-[390px] lg:-right-[80px] pointer-events-none opacity-80 md:opacity-100">
           <div
             className="absolute inset-0"
             style={{


### PR DESCRIPTION
## Summary
- Moves the decorative flower collage further right on desktop viewports (`lg:-right-[80px]`)
- Creates clear visual separation between hero text and the flower decoration
- Improves text readability on large screens

## Test plan
- [x] Verified at 1440px width - text has clear separation from flower
- [x] Verified at 1920px width - layout scales correctly

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)