### PR TITLE
Add Google Analytics (gtag.js) to site head

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,7 +13,16 @@ import '../styles/global.css';
 		<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Fredoka:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 		<meta name="generator" content={Astro.generator} />
 		<title>Comfy - App by Moces | Bem-estar e Conforto Digital</title>
-		
+
+		<!-- Google tag (gtag.js) -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-L0DNH564R3"></script>
+		<script is:inline>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+
+			gtag('config', 'G-L0DNH564R3');
+		</script>
 	</head>
 	<body>
 		<slot />


### PR DESCRIPTION
## Summary

The client (MOCES) asked us to place the Google tag before the closing `</head>` tag on every page of the website that we'll be tracking.

This adds the Google tag (`gtag.js`, measurement ID `G-L0DNH564R3`) to the shared `src/layouts/Layout.astro`. Since both pages (`index.astro` and `termosecondicoes.astro`) render through this layout, the tag is automatically included on every page — before the closing `</head>` — with no per-page changes needed.

## Changes

- `src/layouts/Layout.astro`: Added the Google tag snippet just before `</head>`. The inline initialization `<script>` uses Astro's `is:inline` directive so it runs in global scope (not bundled/scoped by Astro), which is required for `gtag()` to work correctly.

## Verification

- `npm run build` completes successfully.
- Confirmed the built output includes the tag inside `<head>` on both generated pages:
  - `dist/index.html`
  - `dist/termosecondicoes/index.html`

## Client Request

> Coloquem por favor a etiqueta google antes da etiqueta de fecho `</head>` em todas as páginas do seu Website que iremos acompanhar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRJ9VMoZJeEuuGa1Hoxtcr)_