### PR TITLE
Add GDPR consent banner that hard-gates Google Analytics

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -71,7 +71,7 @@ export default function CookieConsent() {
       className="fixed inset-x-0 bottom-0 z-50 px-4 pb-4 sm:px-6 sm:pb-6"
     >
       <div className="container-responsive">
-        <div className="mx-auto max-w-3xl rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.15)] border border-[#e5e7eb] p-5 sm:p-6 font-inter">
+        <div className="mx-auto w-full max-w-[768px] rounded-[20px] bg-white shadow-[0_8px_30px_rgba(0,0,0,0.15)] border border-[#e5e7eb] p-5 sm:p-6 font-inter">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="text-sm text-[#111827] leading-relaxed">
               <p className="font-semibold mb-1">Cookies e privacidade</p>

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'comfy-cookie-consent';
+const OPEN_EVENT = 'comfy:open-cookie-settings';
+
+type Consent = 'granted' | 'denied';
+
+declare global {
+  interface Window {
+    loadComfyAnalytics?: () => void;
+  }
+}
+
+function readConsent(): Consent | null {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY);
+    return value === 'granted' || value === 'denied' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function storeConsent(value: Consent) {
+  try {
+    localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    /* localStorage unavailable (private mode / blocked) — banner will simply reappear next visit */
+  }
+}
+
+export default function CookieConsent() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Show the banner only when the user has not yet made a choice.
+    if (readConsent() === null) {
+      setVisible(true);
+    }
+
+    // Allow the footer link (or any element) to re-open the banner so the
+    // user can change or withdraw their consent at any time.
+    const openHandler = () => setVisible(true);
+    window.addEventListener(OPEN_EVENT, openHandler);
+    return () => window.removeEventListener(OPEN_EVENT, openHandler);
+  }, []);
+
+  const accept = () => {
+    storeConsent('granted');
+    // Load Google Analytics now that consent has been given.
+    window.loadComfyAnalytics?.();
+    setVisible(false);
+  };
+
+  const reject = () => {
+    storeConsent('denied');
+    // Analytics is never loaded. If it had been granted earlier in this
+    // session there is nothing to unload here, but the stored choice stops
+    // it from loading on subsequent visits.
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  const termsUrl = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/termosecondicoes`;
+
+  return (
+    <div
+      role="dialog"
+      aria-live="polite"
+      aria-label="Aviso de cookies"
+      className="fixed inset-x-0 bottom-0 z-50 px-4 pb-4 sm:px-6 sm:pb-6"
+    >
+      <div className="container-responsive">
+        <div className="mx-auto max-w-3xl rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.15)] border border-[#e5e7eb] p-5 sm:p-6 font-inter">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="text-sm text-[#111827] leading-relaxed">
+              <p className="font-semibold mb-1">Cookies e privacidade</p>
+              <p className="text-[#4b5563]">
+                Utilizamos cookies de análise (Google Analytics) para perceber
+                como o site é utilizado e melhorá-lo. Estes cookies só são
+                ativados com o seu consentimento. Pode aceitar ou rejeitar.
+                Saiba mais nos nossos{' '}
+                <a href={termsUrl} className="text-black underline hover:no-underline">
+                  Termos e Condições
+                </a>
+                .
+              </p>
+            </div>
+            <div className="flex flex-shrink-0 gap-3">
+              <button
+                type="button"
+                onClick={reject}
+                className="rounded-full px-6 py-3 font-semibold text-black bg-[#f3f4f6] hover:bg-[#e5e7eb] transition-colors duration-200 cursor-pointer"
+              >
+                Rejeitar
+              </button>
+              <button
+                type="button"
+                onClick={accept}
+                className="rounded-full px-6 py-3 font-semibold text-black bg-[#BEC864] hover:bg-[#B496C8] transition-colors duration-200 cursor-pointer"
+              >
+                Aceitar
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -43,9 +43,25 @@ export default function Footer() {
           </div>
         </div>
 
-        {/* Copyright */}
-        <div className="pt-4 text-center text-sm text-gray-600 font-inter">
+        {/* Copyright + legal links */}
+        <div className="pt-4 text-center text-sm text-gray-600 font-inter space-y-2">
           <p>© 2025 MOCES - Todos os direitos reservados</p>
+          <p className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
+            <a
+              href={`${import.meta.env.BASE_URL.replace(/\/$/, '')}/termosecondicoes`}
+              className="hover:underline"
+            >
+              Termos e Condições
+            </a>
+            <span aria-hidden="true">·</span>
+            <button
+              type="button"
+              onClick={() => window.dispatchEvent(new Event('comfy:open-cookie-settings'))}
+              className="hover:underline cursor-pointer"
+            >
+              Definições de cookies
+            </button>
+          </p>
         </div>
       </div>
     </footer>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -14,14 +14,39 @@ import '../styles/global.css';
 		<meta name="generator" content={Astro.generator} />
 		<title>Comfy - App by Moces | Bem-estar e Conforto Digital</title>
 
-		<!-- Google tag (gtag.js) -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-L0DNH564R3"></script>
+		<!--
+			Google Analytics (gtag.js) — consent-gated for GDPR / ePrivacy (Lei n.º 41/2004).
+			gtag.js is NOT loaded on page load. It is injected only after the user
+			grants consent via the cookie banner, or automatically on later visits if
+			consent was previously granted. Rejecting means it never loads.
+		-->
 		<script is:inline>
-			window.dataLayer = window.dataLayer || [];
-			function gtag(){dataLayer.push(arguments);}
-			gtag('js', new Date());
+			(function () {
+				window.__COMFY_GA_ID = 'G-L0DNH564R3';
 
-			gtag('config', 'G-L0DNH564R3');
+				window.loadComfyAnalytics = function () {
+					if (window.__comfyGaLoaded) return;
+					window.__comfyGaLoaded = true;
+
+					var s = document.createElement('script');
+					s.async = true;
+					s.src = 'https://www.googletagmanager.com/gtag/js?id=' + window.__COMFY_GA_ID;
+					document.head.appendChild(s);
+
+					window.dataLayer = window.dataLayer || [];
+					function gtag(){ dataLayer.push(arguments); }
+					window.gtag = gtag;
+					gtag('js', new Date());
+					gtag('config', window.__COMFY_GA_ID);
+				};
+
+				// Auto-load only if the user previously granted consent.
+				try {
+					if (localStorage.getItem('comfy-cookie-consent') === 'granted') {
+						window.loadComfyAnalytics();
+					}
+				} catch (e) { /* localStorage blocked — stay opted out */ }
+			})();
 		</script>
 	</head>
 	<body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import Contribute from '../components/sections/Contribute.tsx';
 import Transparency from '../components/sections/Transparency.tsx';
 import JoinCause from '../components/sections/JoinCause.tsx';
 import Footer from '../components/layout/Footer.tsx';
+import CookieConsent from '../components/CookieConsent.tsx';
 import Layout from '../layouts/Layout.astro';
 ---
 
@@ -51,6 +52,9 @@ import Layout from '../layouts/Layout.astro';
 
 	<!-- Footer -->
 	<Footer client:load />
+
+	<!-- GDPR cookie consent banner (gates Google Analytics) -->
+	<CookieConsent client:load />
 </Layout>
 
 <style>

--- a/src/pages/termosecondicoes.astro
+++ b/src/pages/termosecondicoes.astro
@@ -1,6 +1,7 @@
 ---
 import LogoZone from '../components/LogoZone.astro';
 import Footer from '../components/layout/Footer.tsx';
+import CookieConsent from '../components/CookieConsent.tsx';
 import Layout from '../layouts/Layout.astro';
 ---
 
@@ -19,7 +20,7 @@ import Layout from '../layouts/Layout.astro';
 			<h1 class="text-4xl md:text-5xl font-bold text-[#111827] mb-4">
 				Termos e Condições
 			</h1>
-			<p class="text-black mb-8">Última atualização: 20 de fevereiro de 2026</p>
+			<p class="text-black mb-8">Última atualização: 16 de julho de 2026</p>
 
 			<div class="space-y-8 text-black">
 				<!-- Intro paragraphs -->
@@ -195,6 +196,22 @@ import Layout from '../layouts/Layout.astro';
 				</section>
 
 				<section>
+					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Cookies e Análise de Dados</h2>
+					<p class="mb-4">
+						Este website utiliza cookies e tecnologias semelhantes. Os cookies estritamente necessários ao funcionamento do site são sempre ativados. Os cookies de análise só são ativados após o consentimento explícito do Visitante, em conformidade com o Regulamento Geral sobre a Proteção de Dados (RGPD) e com a Lei n.º 41/2004, de 18 de agosto (Lei da Privacidade nas Comunicações Eletrónicas).
+					</p>
+					<p class="mb-4">
+						Para efeitos de análise estatística, utilizamos o <strong>Google Analytics</strong>, um serviço prestado pela Google Ireland Limited. Esta ferramenta recolhe informação sobre a utilização do website (como páginas visitadas e duração da visita) através de cookies, com o objetivo de compreender e melhorar a experiência dos utilizadores. No Google Analytics 4, os endereços IP são anonimizados por predefinição e não são armazenados.
+					</p>
+					<p class="mb-4">
+						O Google Analytics <strong>não é carregado</strong> enquanto o Visitante não der o seu consentimento. Ao aceder ao website pela primeira vez, é apresentado um aviso de cookies onde pode <strong>aceitar</strong> ou <strong>rejeitar</strong> os cookies de análise. Se rejeitar, nenhum cookie de análise é criado.
+					</p>
+					<p>
+						O consentimento é guardado no seu navegador e pode ser alterado ou retirado a qualquer momento através da ligação <strong>"Definições de cookies"</strong> disponível no rodapé do website.
+					</p>
+				</section>
+
+				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Alterações aos Termos</h2>
 					<p class="mb-4">
 						A Instituição reserva o direito, a seu critério, a qualquer momento e sem aviso prévio, de modificar, eliminar ou alterar os serviços, os Termos e/ou qualquer página desta App.
@@ -234,4 +251,7 @@ import Layout from '../layouts/Layout.astro';
 
 	<!-- Footer -->
 	<Footer client:load />
+
+	<!-- GDPR cookie consent banner (gates Google Analytics) -->
+	<CookieConsent client:load />
 </Layout>


### PR DESCRIPTION
Portugal falls under GDPR and the ePrivacy law (Lei n.o 41/2004), which
require prior opt-in consent before non-essential trackers are set.
Previously gtag.js loaded unconditionally on page load, setting Google
Analytics cookies before any consent.

- Layout.astro: no longer loads gtag.js on page load. An inline loader
  injects it only when consent is granted, and self-invokes on return
  visits only if consent was previously stored as "granted".
- CookieConsent.tsx: consent banner with equal-weight Accept/Reject.
  Accept loads Analytics and persists the choice; Reject loads nothing.
  Reopens on a "comfy:open-cookie-settings" event so consent can be
  changed or withdrawn.
- Footer.tsx: adds "Definicoes de cookies" (reopen banner) and Terms links.
- index/termosecondicoes: mount the banner.
- termosecondicoes: add a "Cookies e Analise de Dados" section and refresh
  the last-updated date.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014mZoq22mRnyW72Y7wJSorj