### PR TITLE
Update terms page: fix contact block branding and scaffold EN terms

### DIFF
--- a/src/pages/termosecondicoes.astro
+++ b/src/pages/termosecondicoes.astro
@@ -233,7 +233,7 @@ import Layout from '../layouts/Layout.astro';
 						Mensagens enviadas pelo Utilizador à Instituição que não permitam a sua identificação não serão consideradas pela Instituição.
 					</p>
 					<div class="bg-white rounded-lg p-4 border border-[#e5e7eb]">
-						<p class="font-semibold text-[#111827]">Associação MOCES</p>
+						<p class="font-semibold text-[#111827]">Associação MÔÇES</p>
 						<p>NIPC 516126032</p>
 						<p>Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, Querença, Loulé, 8100-129</p>
 						<p>Email: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a></p>
@@ -542,6 +542,24 @@ import Layout from '../layouts/Layout.astro';
 			<!-- ============================================================ -->
 			<!-- ENGLISH                                                      -->
 			<!-- ============================================================ -->
+			<section id="terms-and-conditions" class="scroll-mt-8 mt-16 pt-12 border-t border-[#e5e7eb]">
+				<h2 class="text-3xl md:text-4xl font-bold text-[#111827] mb-4">
+					Terms &amp; Conditions
+				</h2>
+				<p class="text-black mb-2">Comfy App • Associação MÔÇES</p>
+				<p class="text-black mb-8">Last updated: 16 July 2026</p>
+
+				<div class="space-y-8 text-black">
+					<!-- ============================================================ -->
+					<!-- EN TERMS & CONDITIONS CONTENT GOES HERE                      -->
+					<!-- Awaiting the English translation of the "Termos e Condições" -->
+					<!-- section above (provided by the client). Paste the translated -->
+					<!-- blocks here, mirroring the Portuguese section structure.     -->
+					<!-- ============================================================ -->
+					<p class="italic">The English version of the Terms &amp; Conditions will be available soon.</p>
+				</div>
+			</section>
+
 			<section id="privacy-notice" class="scroll-mt-8 mt-16 pt-12 border-t border-[#e5e7eb]">
 				<h2 class="text-3xl md:text-4xl font-bold text-[#111827] mb-4">
 					Privacy Notice

--- a/src/pages/termosecondicoes.astro
+++ b/src/pages/termosecondicoes.astro
@@ -138,7 +138,7 @@ import Layout from '../layouts/Layout.astro';
 				</section>
 				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Resolução de Litígios</h2>
-					<p class="mb-4">Os litígios decorrentes da execução destes Termos são resolvidos através de um procedimento de reclamação. As reclamações e queixas devem ser enviadas à Instituição para o seguinte endereço de e-mail: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+					<p class="mb-4">Os litígios decorrentes da execução destes Termos são resolvidos através de um procedimento de reclamação. As reclamações e queixas devem ser enviadas à Instituição para o seguinte endereço de e-mail: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a>.</p>
 					<p class="mb-4">Caso não seja possível alcançar um acordo, os litígios serão apreciados de acordo com a legislação portuguesa. Para todas as matérias não previstas nestes Termos, as Partes regem-se pela legislação vigente em Portugal.</p>
 				</section>
 				<section>
@@ -164,7 +164,7 @@ import Layout from '../layouts/Layout.astro';
 					<p class="mb-4">A App pode tratar uma quantidade limitada de dados pessoais, incluindo mensagens submetidas voluntariamente através do chat, informações de contacto opcionais fornecidas pelo próprio utilizador e dados técnicos estritamente necessários para o funcionamento e segurança da App. A App não recolhe dados pessoais desnecessários ou excessivos.</p>
 					<p class="mb-4">Os dados pessoais podem ser tratados com base em diferentes fundamentos legais, dependendo da interação. Estes incluem o consentimento e o interesse legítimo, nomeadamente para garantir a segurança, estabilidade e bom funcionamento da App.</p>
 					<p class="mb-4">Os dados pessoais são armazenados de forma segura e conservados apenas pelo período estritamente necessário para as finalidades para as quais foram recolhidos. As mensagens trocadas através do chat podem ser conservadas para controlo interno de qualidade, segurança ou registo, salvo se o titular dos dados solicitar a sua eliminação. Os dados não são mantidos por mais tempo do que o necessário e são eliminados ou anonimizados quando deixarem de ser necessários.</p>
-					<p class="mb-4">Os titulares dos dados têm o direito de aceder aos seus dados pessoais, solicitar a sua correção ou eliminação, retirar o consentimento a qualquer momento e solicitar a limitação do tratamento. Os pedidos relacionados com dados pessoais podem ser enviados para <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+					<p class="mb-4">Os titulares dos dados têm o direito de aceder aos seus dados pessoais, solicitar a sua correção ou eliminação, retirar o consentimento a qualquer momento e solicitar a limitação do tratamento. Os pedidos relacionados com dados pessoais podem ser enviados para <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a>.</p>
 					<p class="mb-4">A Instituição implementa medidas técnicas e organizacionais adequadas para proteger os dados pessoais contra acesso não autorizado, alteração, divulgação ou destruição. Os dados pessoais não são partilhados com terceiros, exceto quando tal seja legalmente exigido ou expressamente autorizado pelo titular dos dados.</p>
 				</section>
 				<section>
@@ -175,13 +175,13 @@ import Layout from '../layouts/Layout.astro';
 				</section>
 				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Contactos</h2>
-					<p class="mb-4">Sugestões, reclamações, questões e outras mensagens do Utilizador relacionadas com o funcionamento do Site ou do Serviço devem ser enviadas à Instituição através do seguinte endereço de e-mail: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+					<p class="mb-4">Sugestões, reclamações, questões e outras mensagens do Utilizador relacionadas com o funcionamento do Site ou do Serviço devem ser enviadas à Instituição através do seguinte endereço de e-mail: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a>.</p>
 					<p class="mb-4">Mensagens enviadas pelo Utilizador à Instituição que não permitam a sua identificação não serão consideradas pela Instituição.</p>
 					<div class="bg-white rounded-lg p-4 border border-[#e5e7eb]">
 						<p class="font-semibold text-[#111827]">Associação MÔÇES</p>
 						<p>NIPC 516126032</p>
 						<p>Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, Querença, Loulé, 8100-129</p>
-						<p>Email: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a></p>
+						<p>Email: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a></p>
 					</div>
 				</section>
 			</div>
@@ -611,7 +611,7 @@ import Layout from '../layouts/Layout.astro';
 					</section>
 					<section>
 						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Disputes Resolution</h2>
-						<p class="mb-4">Disputes arising from the performance of these Terms are resolved through a claims' procedure. Claims and complaints should be sent to the Institution at the following e-mail address: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+						<p class="mb-4">Disputes arising from the performance of these Terms are resolved through a claims' procedure. Claims and complaints should be sent to the Institution at the following e-mail address: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a>.</p>
 						<p class="mb-4">In case an agreement cannot be reached, disputes are considered in accordance with the legislation of Portugal. For all other matters not covered by these Terms, the Parties are guided by the current legislation of Portugal.</p>
 					</section>
 					<section>
@@ -637,7 +637,7 @@ import Layout from '../layouts/Layout.astro';
 						<p class="mb-4">The App may process limited personal data, including messages voluntarily submitted through the chat, optional contact information provided by the individual, and technical data strictly necessary for the functioning and security of the App. The App does not collect unnecessary or excessive personal data.</p>
 						<p class="mb-4">Personal data may be processed under different legal bases depending on the interaction. These include consent and legitimate interest for ensuring the security, stability, and proper functioning of the App.</p>
 						<p class="mb-4">Personal data is stored securely and retained only for the period strictly necessary for the purposes for which it was collected. Messages exchanged through the chat may be retained for internal quality assurance, safety, or record-keeping, unless the individual requests their deletion. Data is not kept longer than required and is deleted or anonymized once no longer needed.</p>
-						<p class="mb-4">Individuals have the right to access their personal data, request its correction or deletion, withdraw consent at any time, request the limitation of processing. Requests regarding personal data may be submitted to <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+						<p class="mb-4">Individuals have the right to access their personal data, request its correction or deletion, withdraw consent at any time, request the limitation of processing. Requests regarding personal data may be submitted to <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a>.</p>
 						<p class="mb-4">The Institution implements appropriate technical and organizational measures to protect personal data against unauthorized access, alteration, disclosure, or destruction. Personal data is not shared with third parties unless legally required or explicitly authorized by the individual.</p>
 					</section>
 					<section>
@@ -648,13 +648,13 @@ import Layout from '../layouts/Layout.astro';
 					</section>
 					<section>
 						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Contact Us</h2>
-						<p class="mb-4">Suggestions, complaints, questions, and other messages from the User regarding the operation of the Site or the Service should be sent to the Institution at the following e-mail address: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+						<p class="mb-4">Suggestions, complaints, questions, and other messages from the User regarding the operation of the Site or the Service should be sent to the Institution at the following e-mail address: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a>.</p>
 						<p class="mb-4">Messages from the User to the Institution that do not allow the User to be identified will not be considered by the Institution.</p>
 						<div class="bg-white rounded-lg p-4 border border-[#e5e7eb]">
 							<p class="font-semibold text-[#111827]">Associação MÔÇES</p>
 							<p>Corporate Number 516126032</p>
 							<p>Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, Querença, Loulé, 8100-129</p>
-							<p>Email: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a></p>
+							<p>Email: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a></p>
 						</div>
 					</section>
 				</div>

--- a/src/pages/termosecondicoes.astro
+++ b/src/pages/termosecondicoes.astro
@@ -69,7 +69,7 @@ import Layout from '../layouts/Layout.astro';
 						<li>restringir funcionalidades ou suspender o acesso em casos de uso indevido, violação destes Termos ou preocupações de segurança.</li>
 					</ul>
 					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Anonimato</h3>
-					<p class="mb-4">A APP está concebida perfil anónimo. A Instituição reserva o direito de aceder à informação pessoal em casos de emergência extrema. Para este efeito, é considerado emergência extrema, mas não limitado a situação de suicídio, violência e qualquer outra que se considere como sendo potencialmente prejudicial.</p>
+					<p class="mb-4">A APP está concebida para perfil anónimo. A Instituição reserva o direito de aceder à informação pessoal em casos de emergência extrema. Para este efeito, é considerado emergência extrema, mas não limitado a situação de suicídio, violência e qualquer outra que se considere como sendo potencialmente prejudicial.</p>
 				</section>
 				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Utilização do Chat</h2>
@@ -146,7 +146,7 @@ import Layout from '../layouts/Layout.astro';
 					<p class="mb-4">A App destina-se a ser utilizada por indivíduos com idades entre 12 e 18 anos.</p>
 					<p class="mb-4">Se tiver menos de 18 anos, o acesso à App só pode ocorrer com o conhecimento, consentimento e supervisão do seu pai/mãe ou tutor legal. O Adulto responsável deve aprovar e supervisionar o acesso e a utilização da App pelo Utilizador, incluindo o seu Conteúdo e a funcionalidade de chat.</p>
 					<p class="mb-4">Determinados Conteúdos, funcionalidades ou serviços podem ser restringidos com base na idade. Alguns materiais ou funcionalidades poderão estar disponíveis apenas para Utilizadores entre 16 e 18 anos, não sendo acessíveis a Utilizadores entre 12 e 15 anos.</p>
-					<p class="mb-4">Embora a Instituição possa implementar medidas técnicas e organizacionais razoáveis para garantir uma utilização adequada à idade, não pode assegurar que todo o Conteúdo será apropriado para cada Utilizador individual. -se que pais, mães e tutores legais supervisionem ativamente a utilização da App pelo menor e avaliem se o Conteúdo acedido é adequado.</p>
+					<p class="mb-4">Embora a Instituição possa implementar medidas técnicas e organizacionais razoáveis para garantir uma utilização adequada à idade, não pode assegurar que todo o Conteúdo será apropriado para cada Utilizador individual. Recomenda-se que pais, mães e tutores legais supervisionem ativamente a utilização da App pelo menor e avaliem se o Conteúdo acedido é adequado.</p>
 					<p class="mb-4">A Instituição reserva o direito de restringir ou limitar o acesso a qualquer parte da App sempre que tal seja necessário por motivos de segurança, conformidade legal ou proteção dos Utilizadores.</p>
 				</section>
 				<section>
@@ -223,7 +223,7 @@ import Layout from '../layouts/Layout.astro';
 							Responsável pelo tratamento: Associação MÔÇES, NIPC 516126032, sede na Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, 8100-129 Querença, Loulé.
 						</p>
 						<p class="mb-4">
-							Email: <a href="mailto:info@zonadesconforto.pt" class="text-black hover:underline">info@zonadesconforto.pt</a>
+							Email: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a>
 						</p>
 						<p>
 							Encarregado de Proteção de Dados (EPD): a MÔÇES não designou EPD, por considerar não se verificarem os critérios de designação obrigatória previstos no artigo 37.º, n.º 1, do RGPD. Para o exercício de direitos ou esclarecimentos sobre o tratamento de dados pessoais, os utilizadores podem contactar-nos através dos contactos acima.
@@ -475,7 +475,7 @@ import Layout from '../layouts/Layout.astro';
 							<p class="font-semibold text-[#111827]">Associação MÔÇES</p>
 							<p>NIPC 516126032</p>
 							<p>Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, 8100-129 Querença, Loulé</p>
-							<p>Email: <a href="mailto:info@zonadesconforto.pt" class="text-black hover:underline">info@zonadesconforto.pt</a></p>
+							<p>Email: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a></p>
 						</div>
 						<p class="mt-4">
 							Ao contactar-nos, poderemos solicitar informação necessária à confirmação da sua identidade.
@@ -518,7 +518,7 @@ import Layout from '../layouts/Layout.astro';
 						<h2 class="text-2xl font-semibold text-[#111827] mb-4">App Description</h2>
 						<p class="mb-4">The core mission of the institution designated as Associação MÔÇES is to promote youth well-being and mental health literacy.</p>
 						<p class="mb-4">The App provides curated suggestions of films, series, books and other media related to youth and mental health, general information on psychological well-being and a chat for informational guidance, clarification of doubts, and sharing of opinions.</p>
-						<p class="mb-4">The Institution does not provide psychotherapy, psychological assessment, crisis intervention nor clinical services through the App. The Content may include fictional works or materials based on realities from other countries  (ie. other than Portugal)</p>
+						<p class="mb-4">The Institution does not provide psychotherapy, psychological assessment, crisis intervention nor clinical services through the App. The Content may include fictional works or materials based on realities from other countries (i.e., other than Portugal).</p>
 						<p class="mb-4">Although the Institution reviews materials to avoid misinformation, it shall not be held liable for the perspectives, interpretations nor opinions expressed in the suggested Content.</p>
 					</section>
 					<section>
@@ -541,7 +541,7 @@ import Layout from '../layouts/Layout.astro';
 							<li>restrict features or suspend access in cases of misuse, violation of these Terms, or security concerns.</li>
 						</ul>
 						<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Anonymity</h3>
-						<p class="mb-4">The APP is to be interacted under anonymous profile. The Institution reserves the right to access personal information in case of extreme emergency. For these purposes extreme emergency shall be considered, but not limited to, treats of suicide, violence and any other that the Institution may identify as potential harmful.</p>
+						<p class="mb-4">The APP is to be interacted under anonymous profile. The Institution reserves the right to access personal information in case of extreme emergency. For these purposes extreme emergency shall be considered, but not limited to, threats of suicide, violence and any other that the Institution may identify as potentially harmful.</p>
 					</section>
 					<section>
 						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Chat</h2>
@@ -558,12 +558,12 @@ import Layout from '../layouts/Layout.astro';
 					</section>
 					<section>
 						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Fee</h2>
-						<p class="mb-4">The Institution does not charge any commission or ay other fees from Users for access  the App.</p>
+						<p class="mb-4">The Institution does not charge any commission or any other fees from Users for accessing the App.</p>
 						<p class="mb-4">However, We plan to introduce paid features for our Users. This will help Us to improve our services and interaction with You. Before introducing paid tariffs, We will provide additional notification about this.</p>
 					</section>
 					<section>
 						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Warranties and Liability</h2>
-						<p class="mb-4">We provide the App and its Content on an “As is” and “As available”. The Institution does not guarantee that the App will always be secure, error-free, free of disruptions or delays.</p>
+						<p class="mb-4">We provide the App and its Content on an “As is” and “As available” basis. The Institution does not guarantee that the App will always be secure, error-free, free of disruptions or delays.</p>
 						<p class="mb-4">Use of the App is at your own risk with due consent of the ADULT.</p>
 						<p class="mb-4">The User and the ADULT acknowledge and agree that the Institution is not responsible for any information provided by third parties, including Employers or Professionals, nor does it take responsibility for (not) providing services, (not) conducting transactions, or any damage caused as a result of actions or inaction, or improper conduct of the User or third parties.</p>
 						<p class="mb-4">The Institution is not responsible for the accuracy, completeness, interpretation, or impact of any Content suggested within the App, including films, series, books, or other media. These materials may include fictional elements or reflect cultural, legal, or social contexts different from those of Portugal. The Institution does not endorse the perspectives presented in such Content.</p>
@@ -602,7 +602,7 @@ import Layout from '../layouts/Layout.astro';
 							<li>strictly adhere to these Terms with the ADULT approval, use the App only for legal purposes in compliance with applicable laws;</li>
 							<li>use the App only for lawful purposes;</li>
 							<li>not engage in actions aimed at destabilizing the App's operation, attempting unauthorized access to the App, disrupting, blocking, or otherwise causing harm to any security means of the App, and not perform any other actions that violate the rights of the Institution and/or third parties;</li>
-							<li>not use the App to commit actions aimed at undermining network security and disrupting the operation of any software and technical means connected to the Internet, as well as committing network attacks on any resources available through the Internet, including the Institution 's software and technical means, but not limited to them;</li>
+							<li>not use the App to commit actions aimed at undermining network security and disrupting the operation of any software and technical means connected to the Internet, as well as committing network attacks on any resources available through the Internet, including the Institution's software and technical means, but not limited to them;</li>
 							<li>not publish content that violates the rights of third parties;</li>
 							<li>notify the Institution of any errors, failures, or security issues detected;</li>
 							<li>not post on the App inaccurate information, any information that may harm reputation, dignity, business reputation, that contains spam or information about financial pyramids, propagates violence, hatred, discrimination, contains links to external Internet resources, violates the rights of third parties, including their contact information, or otherwise violates applicable law.</li>
@@ -694,7 +694,7 @@ import Layout from '../layouts/Layout.astro';
 							Data controller: Associação MÔÇES, NIPC 516126032, headquarters in Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, 8100-129 Querença, Loulé.
 						</p>
 						<p class="mb-4">
-							Email: <a href="mailto:info@zonadesconforto.pt" class="text-black hover:underline">info@zonadesconforto.pt</a>
+							Email: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a>
 						</p>
 						<p>
 							Data Protection Officer (DPO): MÔÇES has not appointed a DPO, as it considers that the mandatory appointment criteria under Article 37(1) GDPR are not met. To exercise rights or for clarifications regarding the processing of personal data, users may contact us using the details above.
@@ -943,7 +943,7 @@ import Layout from '../layouts/Layout.astro';
 							<p class="font-semibold text-[#111827]">Associação MÔÇES</p>
 							<p>NIPC 516126032</p>
 							<p>Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, 8100-129 Querença, Loulé</p>
-							<p>Email: <a href="mailto:info@zonadesconforto.pt" class="text-black hover:underline">info@zonadesconforto.pt</a></p>
+							<p>Email: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a></p>
 						</div>
 						<p class="mt-4">
 							When You contact us, We may ask You to provide information necessary to confirm Your identity.

--- a/src/pages/termosecondicoes.astro
+++ b/src/pages/termosecondicoes.astro
@@ -20,94 +20,113 @@ import Layout from '../layouts/Layout.astro';
 			<h1 class="text-4xl md:text-5xl font-bold text-[#111827] mb-4">
 				Termos e Condições
 			</h1>
-			<p class="text-black mb-8">Última atualização: 16 de julho de 2026</p>
+			<p class="text-black mb-8">Última atualização: 20 de fevereiro de 2026</p>
 
 			<div class="space-y-8 text-black">
-				<!-- Intro paragraphs -->
 				<div>
-					<p class="mb-4">
-						Esta aplicação (referida neste documento como "App") é gerida pela <strong>Associação MOCES</strong>, NIPC 516126032, com sede na Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, Querença, Loulé, 8100-129 (referida neste documento como "Instituição", "Nós"). A Instituição disponibiliza esta App, incluindo todas as informações, ferramentas e serviços nela acessíveis ao Utilizador, estando o seu uso sujeito à aceitação integral de todos os termos, condições, políticas e avisos aqui estabelecidos.
-					</p>
-					<p class="mb-4">
-						Ao utilizar a Nossa App, o Utilizador concorda com estes Termos e Condições (referidos neste documento como "Termos").
-					</p>
-					<p>
-						Os títulos utilizados nestes Termos são incluídos apenas para conveniência e não limitam nem afetam de qualquer forma a interpretação dos mesmos.
-					</p>
+					<p class="mb-4">Esta aplicação (referida neste documento como “App”) é gerida pela Associação MÔÇES, NIPC 516126032, com sede na Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, Querença, Loulé, 8100-129 (referida neste documento como “Instituição”, “Nós”). A Instituição disponibiliza esta App, incluindo todas as informações, ferramentas e serviços nela acessíveis ao Utilizador, estando o seu uso sujeito à aceitação integral de todos os termos, condições, políticas e avisos aqui estabelecidos.</p>
+					<p class="mb-4">Ao utilizar a Nossa App, o Utilizador concorda com estes Termos e Condições (referidos neste documento como “Termos”).</p>
+					<p class="mb-4">Os títulos utilizados nestes Termos são incluídos apenas para conveniência e não limitam nem afetam de qualquer forma a interpretação dos mesmos.</p>
 				</div>
-
 				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Definições</h2>
-					<p class="mb-4">Para efeitos dos presentes Termos, entende-se por:</p>
-					<p class="mb-4">
-						a. <strong>App</strong> - aplicação móvel desenvolvida e operada pela Associação MOCES.
-					</p>
-					<p class="mb-4">
-						b. <strong>Visitante</strong> - pessoa que acede à App sem utilizar o chat.
-					</p>
-					<p class="mb-4">
-						c. <strong>Utilizador</strong> - qualquer pessoa com idade entre 12 e 18 anos que acede ao App, incluindo a funcionalidade de chat e o seu conteúdo.
-					</p>
-					<p class="mb-4">
-						d. <strong>Adulto</strong> - pessoa com 18 anos ou mais, com capacidade legal, que fornece consentimento, supervisiona e assume a responsabilidade pelo acesso e utilização do App e da funcionalidade de chat por parte do menor
-					</p>
-					<p class="mb-4">
-						e. <strong>Conteúdo</strong> - sugestões de filmes, séries, livros e outros materiais relacionados com juventude e saúde mental.
-					</p>
-					<p class="mb-4">
-						f. <strong>Chat</strong> - ferramenta de comunicação destinada a esclarecimentos e partilha de opiniões.
-					</p>
-					<p class="mb-4">
-						g. <strong>Instituição</strong> - entidade responsável pela gestão da App;
-					</p>
-					<p>
-						h. <strong>Anonimato</strong> - a APP permite o acesso aos utilizadores de forma anónima e não necessita de aceder à informação pessoal a não ser nos casos aqui indicados.
-					</p>
+					<p class="mb-4">Para efeitos dos presentes Termos, entende‑se por:</p>
+					<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+						<li><strong>App</strong> - aplicação móvel desenvolvida e operada pela Associação MÔÇES.</li>
+						<li><strong>Visitante</strong> - pessoa que acede à App sem utilizar o chat.</li>
+						<li><strong>Utilizador</strong> - qualquer pessoa com idade entre 12 e 18 anos que acede ao App, incluindo a funcionalidade de chat e o seu conteúdo.</li>
+						<li><strong>Adulto</strong> - pessoa com 18 anos ou mais, com capacidade legal, que fornece consentimento, supervisiona e assume a responsabilidade pelo acesso e utilização do App e da funcionalidade de chat por parte do menor</li>
+						<li><strong>Conteúdo</strong> - sugestões de filmes, séries, livros e outros materiais relacionados com juventude e saúde mental.</li>
+						<li><strong>Chat</strong> - ferramenta de comunicação destinada a esclarecimentos e partilha de opiniões.</li>
+						<li><strong>Instituição</strong> - entidade responsável pela gestão da App;</li>
+						<li><strong>Anonimato </strong> -  a APP permite o acesso aos utilizadores de forma anónima e não necessita de aceder à informação pessoal a não ser nos casos aqui indicados.</li>
+					</ul>
 				</section>
-
 				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Descrição da App</h2>
-					<p class="mb-4">
-						A missão central da instituição designada como Associação MOCES é promover o bem-estar juvenil e a literacia em saúde mental.
-					</p>
-					<p class="mb-4">
-						A App disponibiliza sugestões curadas de filmes, séries, livros e outros materiais de media relacionados com juventude e saúde mental, informação geral sobre o bem-estar psicológico e um chat para orientação informativa, esclarecimento de dúvidas e partilha de opiniões.
-					</p>
-					<p class="mb-4">
-						A Instituição não presta psicoterapia, avaliação psicológica, intervenção em crise nem serviços clínicos através da App. O Conteúdo pode incluir obras ficcionais ou materiais baseados em realidades de outros países (ou seja, diferentes de Portugal).
-					</p>
-					<p>
-						Embora a Instituição reveja os materiais para evitar desinformação, não pode ser responsabilizada pelas perspetivas, interpretações ou opiniões expressas no Conteúdo sugerido.
-					</p>
+					<p class="mb-4">A missão central da instituição designada como Associação MÔÇES é promover o bem-estar juvenil e a literacia em saúde mental.</p>
+					<p class="mb-4">A App disponibiliza sugestões curadas de filmes, séries, livros e outros materiais de media relacionados com juventude e saúde mental, informação geral sobre o bem-estar psicológico e um chat para orientação informativa, esclarecimento de dúvidas e partilha de opiniões.</p>
+					<p class="mb-4">A Instituição não presta psicoterapia, avaliação psicológica, intervenção em crise nem serviços clínicos através da App. O Conteúdo pode incluir obras ficcionais ou materiais baseados em realidades de outros países (ou seja, diferentes de Portugal).</p>
+					<p class="mb-4">Embora a Instituição reveja os materiais para evitar desinformação, não pode ser responsabilizada pelas perspetivas, interpretações ou opiniões expressas no Conteúdo sugerido.</p>
 				</section>
-
 				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Registo de Utilizador</h2>
-
 					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Requisitos de Elegibilidade e Idade</h3>
-					<p class="mb-4">
-						A App destina-se a indivíduos com idades entre 12 e 18 anos. Ao registar-se ou utilizar a App, o Utilizador confirma que se enquadra nesta faixa etária.
-					</p>
-					<p>
-						Determinados Conteúdos e funcionalidades podem ser restringidos com base na idade. Utilizadores entre 16 e 18 anos poderão ter acesso a materiais ou funcionalidades adicionais que não estão disponíveis para Utilizadores entre 12 e 15 anos.
-					</p>
-
+					<p class="mb-4">A App destina-se a indivíduos com idades entre 12 e 18 anos. Ao registar-se ou utilizar a App, o Utilizador confirma que se enquadra nesta faixa etária.</p>
+					<p class="mb-4">Determinados Conteúdos e funcionalidades podem ser restringidos com base na idade. Utilizadores entre 16 e 18 anos poderão ter acesso a materiais ou funcionalidades adicionais que não estão disponíveis para Utilizadores entre 12 e 15 anos.</p>
 					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Consentimento Parental ou do Tutor Legal</h3>
-					<p>
-						Se o Utilizador tiver menos de 18 anos, deve utilizar a App com o conhecimento e consentimento do seu pai, mãe ou tutor legal. O Adulto responsável deve aprovar o acesso do Utilizador e supervisionar a utilização da App e das suas funcionalidades, incluindo o chat.
-					</p>
-
+					<p class="mb-4">Se o Utilizador tiver menos de 18 anos, deve utilizar a App com o conhecimento e consentimento do seu pai, mãe ou tutor legal. O Adulto responsável deve aprovar o acesso do Utilizador e supervisionar a utilização da App e das suas funcionalidades, incluindo o chat.</p>
 					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Criação de Conta</h3>
-					<p class="mb-4">
-						A App requer a criação de uma conta de Utilizador para acesso geral ao seu Conteúdo.
-					</p>
-					<p>
-						Determinadas funcionalidades opcionais, como o chat ou interações personalizadas, podem exigir que o Utilizador forneça informações básicas (como nome ou endereço de e-mail) exclusivamente para fins de comunicação, identificação e prestação do serviço.
-					</p>
-
-					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Obrigações do Utilizador</h3>
-					<p class="mb-4">O Utilizador compromete-se a:</p>
+					<p class="mb-4">A App requer a criação de uma conta de Utilizador para acesso geral ao seu Conteúdo.</p>
+					<p class="mb-4">Determinadas funcionalidades opcionais, como o chat ou interações personalizadas, podem exigir que o Utilizador forneça informações básicas (como nome ou endereço de e-mail) exclusivamente para fins de comunicação, identificação e prestação do serviço.</p>
+					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Autenticação de Terceiros</h3>
+					<p class="mb-4">Se forem disponibilizadas opções de autenticação ou login através de fornecedores externos (como Google, Facebook ou Apple), o Utilizador é responsável por manter a confidencialidade das suas credenciais de acesso e por todas as atividades realizadas através da sua conta.</p>
+					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Direitos da Instituição</h3>
+					<p class="mb-4">A Instituição reserva o direito de:</p>
 					<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+						<li>recusar o registo;</li>
+						<li>limitar o acesso a determinados Conteúdos ou funcionalidades com base na idade;</li>
+						<li>restringir funcionalidades ou suspender o acesso em casos de uso indevido, violação destes Termos ou preocupações de segurança.</li>
+					</ul>
+					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Anonimato</h3>
+					<p class="mb-4">A APP está concebida perfil anónimo. A Instituição reserva o direito de aceder à informação pessoal em casos de emergência extrema. Para este efeito, é considerado emergência extrema, mas não limitado a situação de suicídio, violência e qualquer outra que se considere como sendo potencialmente prejudicial.</p>
+				</section>
+				<section>
+					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Utilização do Chat</h2>
+					<p class="mb-4">O chat destina-se exclusivamente ao esclarecimento geral de dúvidas, orientação informativa, encaminhamento para recursos adequados e incentivo à reflexão crítica sobre o Conteúdo.</p>
+					<p class="mb-4">O chat não deve ser utilizado em situações de emergência e não substitui serviços psicológicos, médicos ou de crise. A Instituição poderá solicitar informações adicionais sempre que necessário para garantir a segurança, a adequação e o cumprimento das diretrizes éticas.</p>
+					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Prestação de Serviços de Psicologia Mediados por Tecnologias da Informação e da Comunicação (TIC)</h3>
+					<h4 class="text-xl font-semibold text-[#111827] mb-3 mt-6">A) Linha de orientação 10.</h4>
+					<p class="mb-4">As/Os psicólogas/os deverão compreender os princípios da sua prática, de modo a que, quando relevante, solicitem consentimento informado assinado para o uso de meios digitais durante os serviços prestados – como, por exemplo, a prestação de serviços online de terapia, mas também qualquer forma de contacto por meio digital (e.g., email). A obtenção do consentimento informado implicará sempre que a/o psicóloga/o tenha conhecimento dos enquadramentos legais e éticos de tal prática, como será o caso, atualmente, do Regulamento (UE) 2016/679 do Parlamento Europeu e do Conselho, de 27 de abril de 2016 e do Código Deontológico da Ordem dos Psicólogos Portugueses.</p>
+					<h4 class="text-xl font-semibold text-[#111827] mb-3 mt-6">B) Linha de orientação 11.</h4>
+					<p class="mb-4">O uso de meios digitais no contacto com a/o cliente acarreta, frequentemente, riscos específicos adicionais que deverão ser considerados na obtenção de tal consentimento. Por exemplo, existem potencialmente maiores dificuldades de verificação da identidade das pessoas, o que, por sua vez, pode acarretar maiores problemas em determinar se a pessoa tem uma idade apropriada para dar o seu consentimento ou se se encontra num estado que limita a capacidade de o dar (e.g., comprometimento ao nível do funcionamento intelectual que limite a sua compreensão do consentimento). Deverão, assim, ser tomadas medidas adequadas que estabeleçam se será necessário consentimento por parte de terceiros, como pais ou outras pessoas e entidades que legalmente representem a/o cliente, para que o trabalho se possa desenvolver; e, se assim for, garantir que este é apropriadamente obtido. Isto poderá requerer procedimentos adicionais de verificação da identidade, como mencionado na linha de orientação 5.</p>
+					<h4 class="text-xl font-semibold text-[#111827] mb-3 mt-6">C) Linha de orientação 12.</h4>
+					<p class="mb-4">O consentimento informado, tendo em conta a natureza dos dados que poderão ser registados de modo digital, deverá compreender informação clara e compreensível pela/o cliente. Este consentimento informado, para lá do habitual consentimento dado em situações de contacto face-a-face, deverá também incluir informações detalhadas sobre o registo e manipulação da informação obtida. A este nível, isto implicará, no mínimo, a descrição dos seguintes elementos: o conteúdo das informações registadas; o(s) objetivo(s) que norteiam a sua realização; os meios e formas de armazenamento; os procedimentos de segurança e de proteção e de destruição adotados; o período de tempo durante o qual serão mantidos; o direito das/os clientes de acederem aos mesmos e/ou de solicitarem a sua destruição; e os procedimentos que serão utilizados caso exista alguma violação da segurança dos dados, incluindo a necessária comunicação dessa falha à/ao cliente ou sua/seu representante legal. Deverão ainda ser explicitados o nível de segurança e riscos que poderão ocorrer em situações específicas 20 pelo uso, por parte da/o psicóloga/o ou pela/o cliente, destas tecnologias. O preço e faturação dos serviços prestados deverá ser sempre clarificado antes do fornecimento dos mesmos. Como tal, o consentimento informado deverá ainda discriminar os serviços prestados e os pagamentos devidos, de modo discriminado e claro, incluindo o tipo de comunicação online estabelecida, os serviços prestados, e o respetivo preço para cada serviço em causa, e o meio de pagamento. Também poderão aqui ser acordados aspetos variados, tais como os seguintes: eventuais tarifas, reembolsos ou indemnizações por interrupção do serviço ou falhas encontradas, reduções de tarifas por falhas na tecnologia, ou outros custos.</p>
+				</section>
+				<section>
+					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Taxas</h2>
+					<p class="mb-4">A Instituição não cobra qualquer comissão ou outras taxas aos Utilizadores pelo acesso à App.</p>
+					<p class="mb-4">No entanto, planeamos introduzir funcionalidades pagas para os nossos Utilizadores. Isto ajudará a melhorar os nossos serviços e a forma como interagimos consigo. Antes de implementar quaisquer tarifas pagas, forneceremos uma notificação adicional.</p>
+				</section>
+				<section>
+					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Garantias e Responsabilidade</h2>
+					<p class="mb-4">Fornecemos a App e o seu Conteúdo “tal como está” e “conforme disponível”. A Instituição não garante que a App será sempre segura, isenta de erros, interrupções ou atrasos.</p>
+					<p class="mb-4">A utilização da App é da responsabilidade do Utilizador, com o devido consentimento do ADULTO responsável.</p>
+					<p class="mb-4">O Utilizador e o ADULTO reconhecem e concordam que a Instituição não é responsável por qualquer informação fornecida por terceiros, incluindo Empregadores ou Profissionais, nem assume responsabilidade por prestar (ou não prestar) serviços, realizar (ou não realizar) transações, ou por quaisquer danos resultantes de ações, omissões ou condutas inadequadas do Utilizador ou de terceiros.</p>
+					<p class="mb-4">A Instituição não é responsável pela exatidão, completude, interpretação ou impacto de qualquer Conteúdo sugerido na App, incluindo filmes, séries, livros ou outros materiais de media. Estes materiais podem incluir elementos ficcionais ou refletir contextos culturais, legais ou sociais diferentes dos de Portugal. A Instituição não endossa as perspetivas apresentadas nesses conteúdos.</p>
+					<p class="mb-4">A Instituição não é responsável por quaisquer decisões, ações ou consequências resultantes da utilização da App, incluindo a confiança em informações fornecidas através do chat. O chat destina-se exclusivamente a orientação informativa e não constitui aconselhamento psicológico, médico, jurídico ou de emergência.</p>
+					<p class="mb-4">A Instituição não é responsável por quaisquer danos decorrentes da utilização ou má utilização da App, incluindo, entre outros: perda de dados, mau funcionamento de dispositivos, danos reputacionais, sofrimento emocional ou quaisquer danos indiretos, incidentais ou consequenciais. A Instituição também não é responsável por acessos não autorizados a comunicações ou dados transmitidos através da App.</p>
+					<p class="mb-4">A Instituição, incluindo a sua direção, colaboradores, prestadores de serviços, agentes e quaisquer indivíduos associados, não será, em circunstância alguma, responsável perante o Utilizador, o ADULTO ou terceiros por quaisquer danos, incluindo perda de lucros, penalidades, perda de dados, danos à honra, dignidade ou reputação profissional, resultantes da utilização ou má utilização da App, da impossibilidade de a utilizar ou do acesso não autorizado às comunicações do Utilizador por terceiros, incluindo, sem limitação, danos causados a dispositivos eletrónicos do Utilizador ou de terceiros, ou a qualquer equipamento ou software relacionado com o uso da App.</p>
+					<p class="mb-4">A Instituição reserva-se o direito de comunicar qualquer atividade que considere ilegal ou contrária a estes Termos e responderá a pedidos confirmados relacionados com investigações (como intimações judiciais, ordens de tribunal ou outros procedimentos legais) provenientes de autoridades policiais ou regulatórias, nacionais ou estrangeiras, bem como de outros agentes governamentais ou terceiros autorizados.</p>
+					<p class="mb-4">A App pode conter ligações para websites ou plataformas externas que não são operadas ou controladas pela Instituição. A inclusão dessas ligações não implica qualquer endosso. A Instituição não é responsável pelo conteúdo, exatidão ou práticas de privacidade desses websites. O acesso a websites de terceiros é feito por conta e risco do Utilizador, que deve consultar os respetivos termos e políticas de privacidade.</p>
+					<p class="mb-4">O Utilizador garante que a informação obtida na App será utilizada apenas para fins pessoais e de forma que não viole quaisquer direitos ou interesses legítimos, incluindo direitos de propriedade intelectual, e que não será transmitida a terceiros. Caso sejam apresentadas reclamações contra a Instituição por terceiros relativamente a informações publicadas pelo Utilizador na App, o Utilizador compromete-se a resolver integralmente, por sua conta e responsabilidade, todos os litígios com os reclamantes e a indemnizar a Instituição por todos os danos sofridos.</p>
+					<p class="mb-4">A Instituição reserva o direito de comunicar qualquer atividade que considere ilícita ou contrária a estes Termos e de cooperar com autoridades policiais ou regulatórias sempre que legalmente exigido.</p>
+					<p class="mb-4">O Visitante e/ou Utilizador garante que todas as secções destes Termos lhe são claras e que as aceita integralmente. Em caso de feedback positivo ou reclamações, o Visitante e/ou Utilizador deve contactar-nos através do endereço de e-mail indicado nestes Termos.</p>
+				</section>
+				<section>
+					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Direitos e Obrigações das Partes</h2>
+					<p class="mb-4">A Instituição tem o direito de:</p>
+					<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+						<li>modificar a App a qualquer momento;</li>
+						<li>suspender ou limitar o acesso por motivos técnicos ou de segurança;</li>
+						<li>remover mensagens que violem estes Termos;</li>
+						<li>contactar os indivíduos para esclarecimentos relacionados com a utilização do chat.</li>
+					</ul>
+					<p class="mb-4">A Instituição é obrigada a:</p>
+					<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+						<li>cumprir estes Termos;</li>
+						<li>proteger os dados pessoais de acordo com o RGPD;</li>
+						<li>não utilizar os dados para finalidades não autorizadas.</li>
+					</ul>
+					<p class="mb-4">O Utilizador tem o direito de:</p>
+					<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+						<li>aceder ao Conteúdo disponível na App;</li>
+						<li>utilizar o chat para fins informativos;</li>
+						<li>contactar a Instituição com sugestões, questões ou reclamações.</li>
+					</ul>
+					<p class="mb-4">O Utilizador é obrigado a:</p>
+					<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+						<li>cumprir rigorosamente estes Termos com a aprovação do ADULTO responsável e utilizar a App apenas para fins legais, em conformidade com a legislação aplicável;</li>
 						<li>utilizar a App exclusivamente para fins lícitos;</li>
 						<li>não realizar ações destinadas a desestabilizar o funcionamento da App, tentar aceder de forma não autorizada à App, interferir, bloquear ou causar danos a quaisquer mecanismos de segurança da App, nem praticar quaisquer outras ações que violem os direitos da Instituição e/ou de terceiros;</li>
 						<li>não utilizar a App para realizar ações que comprometam a segurança da rede ou perturbem o funcionamento de quaisquer meios técnicos ou de software ligados à Internet, incluindo ataques a recursos acessíveis através da Internet, nomeadamente os meios técnicos e de software da Instituição, sem se limitar a estes;</li>
@@ -117,126 +136,52 @@ import Layout from '../layouts/Layout.astro';
 						<li>manter informado sobre os conteúdos da App relacionados com a prestação dos serviços, incluindo alterações e aditamentos a estes Termos.</li>
 					</ul>
 				</section>
-
 				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Resolução de Litígios</h2>
-					<p class="mb-4">
-						Os litígios decorrentes da execução destes Termos são resolvidos através de um procedimento de reclamação. As reclamações e queixas devem ser enviadas à Instituição para o seguinte endereço de e-mail: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a>.
-					</p>
-					<p>
-						Caso não seja possível alcançar um acordo, os litígios serão apreciados de acordo com a legislação portuguesa. Para todas as matérias não previstas nestes Termos, as Partes regem-se pela legislação vigente em Portugal.
-					</p>
+					<p class="mb-4">Os litígios decorrentes da execução destes Termos são resolvidos através de um procedimento de reclamação. As reclamações e queixas devem ser enviadas à Instituição para o seguinte endereço de e-mail: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+					<p class="mb-4">Caso não seja possível alcançar um acordo, os litígios serão apreciados de acordo com a legislação portuguesa. Para todas as matérias não previstas nestes Termos, as Partes regem-se pela legislação vigente em Portugal.</p>
 				</section>
-
 				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Utilização da App por Menores</h2>
-					<p class="mb-4">
-						A App destina-se a ser utilizada por indivíduos com idades entre 12 e 18 anos.
-					</p>
-					<p class="mb-4">
-						Se tiver menos de 18 anos, o acesso à App só pode ocorrer com o conhecimento, consentimento e supervisão do seu pai/mãe ou tutor legal. O Adulto responsável deve aprovar e supervisionar o acesso e a utilização da App pelo Utilizador, incluindo o seu Conteúdo e a funcionalidade de chat.
-					</p>
-					<p class="mb-4">
-						Determinados Conteúdos, funcionalidades ou serviços podem ser restringidos com base na idade. Alguns materiais ou funcionalidades poderão estar disponíveis apenas para Utilizadores entre 16 e 18 anos, não sendo acessíveis a Utilizadores entre 12 e 15 anos.
-					</p>
-					<p class="mb-4">
-						Embora a Instituição possa implementar medidas técnicas e organizacionais razoáveis para garantir uma utilização adequada à idade, não pode assegurar que todo o Conteúdo será apropriado para cada Utilizador individual. Recomenda-se que pais, mães e tutores legais supervisionem ativamente a utilização da App pelo menor e avaliem se o Conteúdo acedido é adequado.
-					</p>
-					<p>
-						A Instituição reserva o direito de restringir ou limitar o acesso a qualquer parte da App sempre que tal seja necessário por motivos de segurança ou conformidade legal, ou quando o comportamento do Utilizador viole estes Termos.
-					</p>
-
-					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Ligações para Sites de Terceiros</h3>
-					<p>
-						A App pode conter ligações para websites ou recursos externos não operados pela Instituição. A inclusão dessas ligações não implica qualquer endosso. A Instituição não é responsável pelo conteúdo, exatidão ou práticas de privacidade desses websites. O acesso a websites de terceiros é feito por conta e risco do Utilizador, que deve consultar os respetivos termos e políticas de privacidade.
-					</p>
-
-					<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Utilização da Informação</h3>
-					<p class="mb-4">
-						O Utilizador garante que a informação obtida na App será utilizada apenas para fins pessoais e de forma que não viole quaisquer direitos ou interesses legítimos, incluindo direitos de propriedade intelectual, e que não será transmitida a terceiros. Caso sejam apresentadas reclamações contra a Instituição por terceiros relativamente a informações publicadas pelo Utilizador na App, o Utilizador compromete-se a resolver integralmente, por sua conta e responsabilidade, todos os litígios com os reclamantes e a indemnizar a Instituição por todos os danos sofridos.
-					</p>
-					<p class="mb-4">
-						A Instituição reserva o direito de comunicar qualquer atividade que considere ilícita ou contrária a estes Termos e de cooperar com autoridades policiais ou regulatórias sempre que legalmente exigido.
-					</p>
-					<p>
-						O Visitante e/ou Utilizador garante que todas as secções destes Termos lhe são claras e que as aceita integralmente. Em caso de feedback positivo ou reclamações, o Visitante e/ou Utilizador deve contactar-nos através do endereço de e-mail indicado nestes Termos.
-					</p>
+					<p class="mb-4">A App destina-se a ser utilizada por indivíduos com idades entre 12 e 18 anos.</p>
+					<p class="mb-4">Se tiver menos de 18 anos, o acesso à App só pode ocorrer com o conhecimento, consentimento e supervisão do seu pai/mãe ou tutor legal. O Adulto responsável deve aprovar e supervisionar o acesso e a utilização da App pelo Utilizador, incluindo o seu Conteúdo e a funcionalidade de chat.</p>
+					<p class="mb-4">Determinados Conteúdos, funcionalidades ou serviços podem ser restringidos com base na idade. Alguns materiais ou funcionalidades poderão estar disponíveis apenas para Utilizadores entre 16 e 18 anos, não sendo acessíveis a Utilizadores entre 12 e 15 anos.</p>
+					<p class="mb-4">Embora a Instituição possa implementar medidas técnicas e organizacionais razoáveis para garantir uma utilização adequada à idade, não pode assegurar que todo o Conteúdo será apropriado para cada Utilizador individual. -se que pais, mães e tutores legais supervisionem ativamente a utilização da App pelo menor e avaliem se o Conteúdo acedido é adequado.</p>
+					<p class="mb-4">A Instituição reserva o direito de restringir ou limitar o acesso a qualquer parte da App sempre que tal seja necessário por motivos de segurança, conformidade legal ou proteção dos Utilizadores.</p>
 				</section>
-
 				<section>
-					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Direitos e Obrigações das Partes</h2>
-
-					<p class="mb-4"><strong>A Instituição tem o direito de:</strong></p>
-					<ul class="list-disc list-inside ml-4 mt-2 space-y-1 mb-6">
-						<li>modificar a App a qualquer momento;</li>
-						<li>suspender ou limitar o acesso por motivos técnicos ou de segurança;</li>
-						<li>remover mensagens que violem estes Termos;</li>
-						<li>contactar os indivíduos para esclarecimentos relacionados com a utilização do chat.</li>
-					</ul>
-
-					<p class="mb-4"><strong>A Instituição é obrigada a:</strong></p>
-					<ul class="list-disc list-inside ml-4 mt-2 space-y-1 mb-6">
-						<li>cumprir estes Termos;</li>
-						<li>proteger os dados pessoais de acordo com o RGPD;</li>
-						<li>não utilizar os dados para finalidades não autorizadas.</li>
-					</ul>
-
-					<p class="mb-4"><strong>O Utilizador tem o direito de:</strong></p>
-					<ul class="list-disc list-inside ml-4 mt-2 space-y-1 mb-6">
-						<li>aceder ao Conteúdo disponível na App;</li>
-						<li>utilizar o chat para fins informativos;</li>
-						<li>contactar a Instituição com sugestões, questões ou reclamações.</li>
-					</ul>
-
-					<p class="mb-4"><strong>O Utilizador é obrigado a:</strong></p>
-					<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
-						<li>cumprir rigorosamente estes Termos com a aprovação do ADULTO responsável e utilizar a App apenas para fins legais, em conformidade com a legislação aplicável;</li>
-						<li>legalmente exigido ou expressamente autorizado pelo titular dos dados.</li>
-					</ul>
+					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Propriedade Intelectual</h2>
+					<p class="mb-4">Todas as informações contidas na App são, por definição, propriedade intelectual exclusiva da Associação MÔÇES. As marcas, logótipos e sinais distintivos registados de acordo com a legislação aplicável, bem como os conteúdos protegidos por direitos de autor (textos, imagens visuais ou outros) disponibilizados na App pela Instituição, são propriedade da Instituição.</p>
+					<p class="mb-4">Nenhum conteúdo pode ser interpretado como conferindo qualquer direito ou permissão para utilizar marcas registadas ou quaisquer outros materiais disponibilizados na App pela Instituição sem o consentimento da própria Instituição enquanto titular dos direitos de autor.</p>
 				</section>
-
 				<section>
-					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Cookies e Análise de Dados</h2>
-					<p class="mb-4">
-						Este website utiliza cookies e tecnologias semelhantes. Os cookies estritamente necessários ao funcionamento do site são sempre ativados. Os cookies de análise só são ativados após o consentimento explícito do Visitante, em conformidade com o Regulamento Geral sobre a Proteção de Dados (RGPD) e com a Lei n.º 41/2004, de 18 de agosto (Lei da Privacidade nas Comunicações Eletrónicas).
-					</p>
-					<p class="mb-4">
-						Para efeitos de análise estatística, utilizamos o <strong>Google Analytics</strong>, um serviço prestado pela Google Ireland Limited. Esta ferramenta recolhe informação sobre a utilização do website (como páginas visitadas e duração da visita) através de cookies, com o objetivo de compreender e melhorar a experiência dos utilizadores. No Google Analytics 4, os endereços IP são anonimizados por predefinição e não são armazenados.
-					</p>
-					<p class="mb-4">
-						O Google Analytics <strong>não é carregado</strong> enquanto o Visitante não der o seu consentimento. Ao aceder ao website pela primeira vez, é apresentado um aviso de cookies onde pode <strong>aceitar</strong> ou <strong>rejeitar</strong> os cookies de análise. Se rejeitar, nenhum cookie de análise é criado.
-					</p>
-					<p>
-						O consentimento é guardado no seu navegador e pode ser alterado ou retirado a qualquer momento através da ligação <strong>"Definições de cookies"</strong> disponível no rodapé do website.
-					</p>
+					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Consentimento Informado para Contacto Digital</h2>
+					<p class="mb-4">Sempre que o contacto digital envolver a troca de informações pessoais ou sensíveis, a Instituição poderá solicitar consentimento informado, o qual incluirá: a finalidade da comunicação; o tipo de dados recolhidos; a forma e o período de armazenamento dos dados; as medidas de segurança adotadas; os riscos associados à comunicação digital; os direitos do titular dos dados ao abrigo do RGPD; e a necessidade de consentimento dos representantes legais, quando aplicável.</p>
+					<p class="mb-4">Poderá ser necessária a verificação de identidade para garantir a segurança e a adequação do apoio prestado.</p>
 				</section>
-
+				<section>
+					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Segurança e Proteção de Dados</h2>
+					<p class="mb-4">A App pode tratar uma quantidade limitada de dados pessoais, incluindo mensagens submetidas voluntariamente através do chat, informações de contacto opcionais fornecidas pelo próprio utilizador e dados técnicos estritamente necessários para o funcionamento e segurança da App. A App não recolhe dados pessoais desnecessários ou excessivos.</p>
+					<p class="mb-4">Os dados pessoais podem ser tratados com base em diferentes fundamentos legais, dependendo da interação. Estes incluem o consentimento e o interesse legítimo, nomeadamente para garantir a segurança, estabilidade e bom funcionamento da App.</p>
+					<p class="mb-4">Os dados pessoais são armazenados de forma segura e conservados apenas pelo período estritamente necessário para as finalidades para as quais foram recolhidos. As mensagens trocadas através do chat podem ser conservadas para controlo interno de qualidade, segurança ou registo, salvo se o titular dos dados solicitar a sua eliminação. Os dados não são mantidos por mais tempo do que o necessário e são eliminados ou anonimizados quando deixarem de ser necessários.</p>
+					<p class="mb-4">Os titulares dos dados têm o direito de aceder aos seus dados pessoais, solicitar a sua correção ou eliminação, retirar o consentimento a qualquer momento e solicitar a limitação do tratamento. Os pedidos relacionados com dados pessoais podem ser enviados para <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+					<p class="mb-4">A Instituição implementa medidas técnicas e organizacionais adequadas para proteger os dados pessoais contra acesso não autorizado, alteração, divulgação ou destruição. Os dados pessoais não são partilhados com terceiros, exceto quando tal seja legalmente exigido ou expressamente autorizado pelo titular dos dados.</p>
+				</section>
 				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Alterações aos Termos</h2>
-					<p class="mb-4">
-						A Instituição reserva o direito, a seu critério, a qualquer momento e sem aviso prévio, de modificar, eliminar ou alterar os serviços, os Termos e/ou qualquer página desta App.
-					</p>
-					<p class="mb-4">
-						A data de "Última Atualização" acima indicará quando os Termos foram revistos pela última vez. Ao continuar a utilizar a App após essa data, o Utilizador aceita as alterações efetuadas.
-					</p>
-					<p>
-						Se qualquer disposição destes Termos for considerada inválida ou inexequível em determinadas circunstâncias, tal não afeta a sua aplicação noutras circunstâncias, permanecendo as restantes disposições válidas e plenamente aplicáveis.
-					</p>
+					<p class="mb-4">A Instituição reserva o direito, a seu critério, a qualquer momento e sem aviso prévio, de modificar, eliminar ou alterar os serviços, os Termos e/ou qualquer página desta App.</p>
+					<p class="mb-4">A data de “Última Atualização” acima indicará quando os Termos foram revistos pela última vez. Ao continuar a utilizar a App após essa data, o Utilizador aceita as alterações efetuadas.</p>
+					<p class="mb-4">Se qualquer disposição destes Termos for considerada inválida ou inexequível em determinadas circunstâncias, tal não afeta a sua aplicação noutras circunstâncias, permanecendo as restantes disposições válidas e plenamente aplicáveis.</p>
 				</section>
-
 				<section>
 					<h2 class="text-2xl font-semibold text-[#111827] mb-4">Contactos</h2>
-					<p class="mb-4">
-						Sugestões, reclamações, questões e outras mensagens do Utilizador relacionadas com o funcionamento do Site ou do Serviço devem ser enviadas à Instituição através do seguinte endereço de e-mail: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a>.
-					</p>
-					<p class="mb-4">
-						Mensagens enviadas pelo Utilizador à Instituição que não permitam a sua identificação não serão consideradas pela Instituição.
-					</p>
+					<p class="mb-4">Sugestões, reclamações, questões e outras mensagens do Utilizador relacionadas com o funcionamento do Site ou do Serviço devem ser enviadas à Instituição através do seguinte endereço de e-mail: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+					<p class="mb-4">Mensagens enviadas pelo Utilizador à Instituição que não permitam a sua identificação não serão consideradas pela Instituição.</p>
 					<div class="bg-white rounded-lg p-4 border border-[#e5e7eb]">
 						<p class="font-semibold text-[#111827]">Associação MÔÇES</p>
 						<p>NIPC 516126032</p>
 						<p>Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, Querença, Loulé, 8100-129</p>
-						<p>Email: <a href="mailto:ola@moces.pt" class="text-black hover:underline">ola@moces.pt</a></p>
+						<p>Email: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a></p>
 					</div>
 				</section>
 			</div>
@@ -547,16 +492,171 @@ import Layout from '../layouts/Layout.astro';
 					Terms &amp; Conditions
 				</h2>
 				<p class="text-black mb-2">Comfy App • Associação MÔÇES</p>
-				<p class="text-black mb-8">Last updated: 16 July 2026</p>
+				<p class="text-black mb-8">Last updated: 20th March 2026</p>
 
 				<div class="space-y-8 text-black">
-					<!-- ============================================================ -->
-					<!-- EN TERMS & CONDITIONS CONTENT GOES HERE                      -->
-					<!-- Awaiting the English translation of the "Termos e Condições" -->
-					<!-- section above (provided by the client). Paste the translated -->
-					<!-- blocks here, mirroring the Portuguese section structure.     -->
-					<!-- ============================================================ -->
-					<p class="italic">The English version of the Terms &amp; Conditions will be available soon.</p>
+					<div>
+						<p class="mb-4">This application (referenced herein with “App”) is managed by Associação MÔÇES, Corporate Number 516126032, with a registered office at Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, Querença, Loulé, 8100-129 (referenced herein with “Institution”, “We”, “Us”). The Institution provides this Site, including all information, tools, and services available on this site to the User, subject to your acceptance of all terms, conditions, policies, and notices stated here.</p>
+						<p class="mb-4">By using Our App, You agree to these Terms &amp; Conditions (referenced herein with “Terms”).</p>
+						<p class="mb-4">The headings used in these Terms are included for convenience only and do not limit or otherwise affect these Terms.</p>
+					</div>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Definitions</h2>
+						<p class="mb-4">In this document, the definitions listed below are used interchangeably in the singular and plural (unless otherwise specified in the term and/or definition) in the following meanings:</p>
+						<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+							<li><strong>App</strong> - the mobile application developed and operated by Associação MÔÇES;</li>
+							<li><strong>Visitor</strong> - any person who accesses the App without using the chat or sending messages;</li>
+							<li><strong>User</strong> - any person aged between 12 to 18 that accesses the App, including the chat functionality and its content;</li>
+							<li><strong>Adult</strong> - a person who is 18 years of age or older, who has legal capacity and who provides consent for, supervises, and assumes responsibility for the minor’s access to and use of the App and its chat functionality;</li>
+							<li><strong>Content</strong> - suggestions of films, series, books, and other media materials related to youth and mental health made available within the App;</li>
+							<li><strong>Chat</strong> - the communication tool that allows Users to ask questions, request clarifications, or share opinions regarding the Content;</li>
+							<li><strong>Institution</strong> – Associação MÔÇES, the entity responsible for managing the App and its functionalities;</li>
+							<li><strong>Anonymity</strong>: the APP allows users to access and use its services anonymously and does not require the disclosure of the personal data unless when it is hereby indicated.</li>
+						</ul>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">App Description</h2>
+						<p class="mb-4">The core mission of the institution designated as Associação MÔÇES is to promote youth well-being and mental health literacy.</p>
+						<p class="mb-4">The App provides curated suggestions of films, series, books and other media related to youth and mental health, general information on psychological well-being and a chat for informational guidance, clarification of doubts, and sharing of opinions.</p>
+						<p class="mb-4">The Institution does not provide psychotherapy, psychological assessment, crisis intervention nor clinical services through the App. The Content may include fictional works or materials based on realities from other countries  (ie. other than Portugal)</p>
+						<p class="mb-4">Although the Institution reviews materials to avoid misinformation, it shall not be held liable for the perspectives, interpretations nor opinions expressed in the suggested Content.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">User Registration</h2>
+						<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Eligibility and Age Requirements</h3>
+						<p class="mb-4">The App is intended for individuals aged 12 to 18 years old. By registering or using the App, You confirm that You fall within this age range.</p>
+						<p class="mb-4">Certain Content and features may be restricted based on age. Users aged 16 to 18 may have access to additional materials or functionalities that are not available to Users aged 12 to 15.</p>
+						<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Parental or Guardian Consent</h3>
+						<p class="mb-4">If You are under the age of 18, You must use the App with the knowledge and consent of Your parent or legal guardian. The supervising Adult is responsible for approving the User’s access and overseeing their use of the App and its features, including the chat functionality.</p>
+						<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Account Creation</h3>
+						<p class="mb-4">The App requires the creation of a User account for general access to its Content.</p>
+						<p class="mb-4">Certain optional features, such as chat or personalized interactions, may require the User to provide basic information (such as a name or e-mail address) solely for communication, identification, and service purposes.</p>
+						<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Third-Party Authentication</h3>
+						<p class="mb-4">If authentication or login options are offered through third-party providers (such as Google, Facebook, or Apple), the User is responsible for maintaining the confidentiality of their login credentials and for all activities carried out through their account.</p>
+						<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Institution Rights</h3>
+						<p class="mb-4">The Institution reserves the right to:</p>
+						<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+							<li>refuse registration;</li>
+							<li>limit access to certain Content or features based on age;</li>
+							<li>restrict features or suspend access in cases of misuse, violation of these Terms, or security concerns.</li>
+						</ul>
+						<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Anonymity</h3>
+						<p class="mb-4">The APP is to be interacted under anonymous profile. The Institution reserves the right to access personal information in case of extreme emergency. For these purposes extreme emergency shall be considered, but not limited to, treats of suicide, violence and any other that the Institution may identify as potential harmful.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Chat</h2>
+						<p class="mb-4">The chat is intended exclusively for general clarification of doubts, informational guidance, referral to appropriate resources, encouraging critical reflection on the Content.</p>
+						<p class="mb-4">The chat shall not be used in emergencies and does not replace psychological, medical, or crisis services. The Institution may request additional information when necessary to ensure safety, appropriateness and compliance with ethical guidelines.</p>
+						<h3 class="text-xl font-semibold text-[#111827] mb-3 mt-6">Provision of Psychological Services Mediated by Information and Communication Technologies (ICT)</h3>
+						<h4 class="text-xl font-semibold text-[#111827] mb-3 mt-6">A) Guideline 10</h4>
+						<p class="mb-4">Psychologists shall understand the principles underlying their professional practice so that, whenever relevant, they request signed informed consent for the use of digital means during the provision of services — for example, the delivery of online therapy, but also any form of contact carried out through digital media (e.g., email). Obtaining informed consent always requires that the psychologist is aware of the legal and ethical frameworks governing such practice, including, at present, Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 (GDPR), as well as the Code of Ethics of the Portuguese Psychologists’ Institution.</p>
+						<h4 class="text-xl font-semibold text-[#111827] mb-3 mt-6">B) Guideline 11</h4>
+						<p class="mb-4">The use of digital means when contacting clients frequently entails additional, specific risks that must be considered when obtaining informed consent. For example, verifying a person’s identity may be more difficult, which in turn may create challenges in determining whether the individual is of an appropriate age to provide consent or whether they are in a condition that limits their capacity to do so (e.g., intellectual functioning impairments that restrict their understanding of the consent process). Appropriate measures must therefore be taken to determine whether third-party consent is required — such as from parents or other individuals or entities legally representing the client — in order for the work to proceed; and, if so, to ensure that such consent is properly obtained. This may require additional identity-verification procedures, as mentioned in Guideline 5.</p>
+						<h4 class="text-xl font-semibold text-[#111827] mb-3 mt-6">C) Guideline 12</h4>
+						<p class="mb-4">Given the nature of the data that may be digitally recorded, informed consent must include clear and comprehensible information for the client. In addition to the usual elements required in face-to-face settings, informed consent must also include detailed information regarding the recording and handling of the data obtained. At a minimum, this shall include: the content of the information recorded; the purpose(s) for which it is collected; the means and forms of storage; the security, protection and destruction procedures adopted; the period for which the data will be retained; the client’s right to access the data and/or request its deletion and the procedures to be followed in the event of a data-security breach, including the obligation to notify the client or their legal representative.</p>
+						<p class="mb-4">The level of security and the risks that may arise in specific situations due to the use of these technologies - whether by the psychologist or by the client  - must also be clearly explained. The price and invoicing of the services provided must always be clarified prior to their delivery. Accordingly, informed consent must also specify, in a clear and itemized manner, the services to be provided and the corresponding fees, including the type of online communication used, the services delivered, the cost of each service, and the method of payment.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Fee</h2>
+						<p class="mb-4">The Institution does not charge any commission or ay other fees from Users for access  the App.</p>
+						<p class="mb-4">However, We plan to introduce paid features for our Users. This will help Us to improve our services and interaction with You. Before introducing paid tariffs, We will provide additional notification about this.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Warranties and Liability</h2>
+						<p class="mb-4">We provide the App and its Content on an “As is” and “As available”. The Institution does not guarantee that the App will always be secure, error-free, free of disruptions or delays.</p>
+						<p class="mb-4">Use of the App is at your own risk with due consent of the ADULT.</p>
+						<p class="mb-4">The User and the ADULT acknowledge and agree that the Institution is not responsible for any information provided by third parties, including Employers or Professionals, nor does it take responsibility for (not) providing services, (not) conducting transactions, or any damage caused as a result of actions or inaction, or improper conduct of the User or third parties.</p>
+						<p class="mb-4">The Institution is not responsible for the accuracy, completeness, interpretation, or impact of any Content suggested within the App, including films, series, books, or other media. These materials may include fictional elements or reflect cultural, legal, or social contexts different from those of Portugal. The Institution does not endorse the perspectives presented in such Content.</p>
+						<p class="mb-4">The Institution is not responsible for any decisions, actions, or outcomes resulting from the use of the App, including reliance on information provided through the chat. The chat is intended solely for informational guidance and does not constitute psychological, medical, legal or emergency advice.</p>
+						<p class="mb-4">The Institution is not liable for any damages arising from the use or misuse of the App, including but not limited to: loss of data, device malfunction, reputational harm, emotional distress, or any indirect, incidental, or consequential damages. The Institution is also not responsible for unauthorized access to communications or data transmitted through the App.</p>
+						<p class="mb-4">The Institution, including its management, employees, contractors, agents and affiliated individuals with the Institution, under no circumstances, shall be liable to the User nor the ADULT or any third parties for any damages, including loss of profit and imposed penalties, or lost data, damage to honor, dignity, or business reputation incurred in connection with the use or misuse of the Site by them, or the inability to use it, or unauthorized access to the User's communications by third parties, including, without limitation, cases of damage caused to the User's electronic devices or other persons, any other equipment, or software related to the use or misuse of the App.</p>
+						<p class="mb-4">We reserve the right to report any activity that the Institution considers illegal or otherwise contrary to these Terms, and We will respond to any confirmed requests related to investigations (such as a court summons, court order, or other legal process) from local and foreign law enforcement or regulatory authorities, other government officials, or authorized third parties.</p>
+						<p class="mb-4">The App may contain links to external websites or platforms that are not operated or controlled by the Institution. The inclusion of such links does not imply endorsement. The Institution is not responsible for the content, accuracy, or privacy practices of external websites. Users access third-party websites at their own risk and should review their respective terms and privacy policies.</p>
+						<p class="mb-4">The User guarantees that the information obtained by them on the App will be used personally and in a manner that does not violate any rights and legal interests, including intellectual property rights, and will not be transferred to third parties. In case of claims against the Institution by third parties regarding the information posted by the User on the App, the User is obliged to independently and at their own expense settle and resolve all disputes with the parties that filed the claims and compensate the Institution for all incurred damages in full.</p>
+						<p class="mb-4">The Institution reserves the right to report any activity it considers unlawful or contrary to these Terms and to cooperate with law enforcement or regulatory authorities when legally required.</p>
+						<p class="mb-4">Visitor and/or User guarantees that all sections of these Terms are clear to them, and they accept them in full. In case of positive feedback or claims from the Visitor and/or User, they should contact Us at the e-mail address specified in these Terms.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Parties Rights and Obligations</h2>
+						<p class="mb-4">The Institution has the right to:</p>
+						<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+							<li>modify the App at any time;</li>
+							<li>suspend or limit access for technical or security reasons;</li>
+							<li>remove messages that violate these Terms;</li>
+							<li>contact individuals for clarifications related to chat usage.</li>
+						</ul>
+						<p class="mb-4">The Institution is obligated to:</p>
+						<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+							<li>comply with these Terms;</li>
+							<li>protect personal data in accordance with the GDPR;</li>
+							<li>not use data for unauthorized purposes.</li>
+						</ul>
+						<p class="mb-4">The User has the right to:</p>
+						<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+							<li>access the Content available in the App;</li>
+							<li>use the chat for informational purposes;</li>
+							<li>contact the Institution with suggestions, questions, or complaints.</li>
+						</ul>
+						<p class="mb-4">The User is obligated to:</p>
+						<ul class="list-disc list-inside ml-4 mt-2 space-y-1">
+							<li>strictly adhere to these Terms with the ADULT approval, use the App only for legal purposes in compliance with applicable laws;</li>
+							<li>use the App only for lawful purposes;</li>
+							<li>not engage in actions aimed at destabilizing the App's operation, attempting unauthorized access to the App, disrupting, blocking, or otherwise causing harm to any security means of the App, and not perform any other actions that violate the rights of the Institution and/or third parties;</li>
+							<li>not use the App to commit actions aimed at undermining network security and disrupting the operation of any software and technical means connected to the Internet, as well as committing network attacks on any resources available through the Internet, including the Institution 's software and technical means, but not limited to them;</li>
+							<li>not publish content that violates the rights of third parties;</li>
+							<li>notify the Institution of any errors, failures, or security issues detected;</li>
+							<li>not post on the App inaccurate information, any information that may harm reputation, dignity, business reputation, that contains spam or information about financial pyramids, propagates violence, hatred, discrimination, contains links to external Internet resources, violates the rights of third parties, including their contact information, or otherwise violates applicable law.</li>
+							<li>get acquainted with the information on the App related to the provision of services, including changes and additions to these Terms.</li>
+						</ul>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Disputes Resolution</h2>
+						<p class="mb-4">Disputes arising from the performance of these Terms are resolved through a claims' procedure. Claims and complaints should be sent to the Institution at the following e-mail address: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+						<p class="mb-4">In case an agreement cannot be reached, disputes are considered in accordance with the legislation of Portugal. For all other matters not covered by these Terms, the Parties are guided by the current legislation of Portugal.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Use of the App by Under Aged</h2>
+						<p class="mb-4">The App is intended to be accessed by individuals aged 12 to 18 years old.</p>
+						<p class="mb-4">If You are under 18 years of age, the App may be accessed only with the knowledge, consent, and supervision of Your parent or legal guardian. The supervising Adult is responsible for approving and overseeing the User’s access to and use of the App, including its Content and chat functionality.</p>
+						<p class="mb-4">Certain Content, features, or services may be restricted based on age. Some materials or functionalities may only be accessed by Users aged 16 to 18, and will not be available to Users aged 12 to 15.</p>
+						<p class="mb-4">While the Institution may implement reasonable technical and organizational measures to ensure age-appropriate use, it cannot guarantee that all Content will be suitable for every individual User. Parents and legal guardians are encouraged to actively supervise the minor’s use of the App and to determine whether the Content accessed is appropriate.</p>
+						<p class="mb-4">The Institution reserves the right to restrict or limit access to any part of the App where necessary for safety, legal compliance, or the protection of Users.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Intellectual Property</h2>
+						<p class="mb-4">All information contained on the App is, by default, the exclusive intellectual property of the Associação MÔÇES. Trademarks, brands, logos registered according to the current legislation, as well as copyright-protected objects (texts, visual images, and otherwise) posted on the App by the Institution, are the property of the Institution.</p>
+						<p class="mb-4">No content can be interpreted as a right or permission to use any trademarks or any other materials posted on the App by the Institution without the consent of the Institution as the owner of the copyright.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Informed Consent for Digital Contact</h2>
+						<p class="mb-4">Whenever digital contact involves the exchange of personal or sensitive information, the Institution may request informed consent, which will include the purpose of the communication; the type of data collected; how and for how long the data will be stored; security measures adopted; risks associated with digital communication; the individual’s rights under the GDPR; the need for consent from legal guardians when applicable.</p>
+						<p class="mb-4">Identity verification may be required to ensure safety and appropriateness of the support provided.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Data Security and Protection</h2>
+						<p class="mb-4">The App may process limited personal data, including messages voluntarily submitted through the chat, optional contact information provided by the individual, and technical data strictly necessary for the functioning and security of the App. The App does not collect unnecessary or excessive personal data.</p>
+						<p class="mb-4">Personal data may be processed under different legal bases depending on the interaction. These include consent and legitimate interest for ensuring the security, stability, and proper functioning of the App.</p>
+						<p class="mb-4">Personal data is stored securely and retained only for the period strictly necessary for the purposes for which it was collected. Messages exchanged through the chat may be retained for internal quality assurance, safety, or record-keeping, unless the individual requests their deletion. Data is not kept longer than required and is deleted or anonymized once no longer needed.</p>
+						<p class="mb-4">Individuals have the right to access their personal data, request its correction or deletion, withdraw consent at any time, request the limitation of processing. Requests regarding personal data may be submitted to <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+						<p class="mb-4">The Institution implements appropriate technical and organizational measures to protect personal data against unauthorized access, alteration, disclosure, or destruction. Personal data is not shared with third parties unless legally required or explicitly authorized by the individual.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Changes to the Terms</h2>
+						<p class="mb-4">The Institution reserves the right at its discretion, at any time, and without prior notice, to modify, delete, or amend the services or the Terms and/or any page of this App.</p>
+						<p class="mb-4">The “Last Updated” date above will indicate when the Terms were last reviewed. By continuing to use this App after this date, You agree to the changes.</p>
+						<p class="mb-4">If any provision of these Terms is deemed invalid or unenforceable under any circumstances, it does not affect its application under any other circumstances and the other provisions of these Terms remain valid and enforceable.</p>
+					</section>
+					<section>
+						<h2 class="text-2xl font-semibold text-[#111827] mb-4">Contact Us</h2>
+						<p class="mb-4">Suggestions, complaints, questions, and other messages from the User regarding the operation of the Site or the Service should be sent to the Institution at the following e-mail address: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a>.</p>
+						<p class="mb-4">Messages from the User to the Institution that do not allow the User to be identified will not be considered by the Institution.</p>
+						<div class="bg-white rounded-lg p-4 border border-[#e5e7eb]">
+							<p class="font-semibold text-[#111827]">Associação MÔÇES</p>
+							<p>Corporate Number 516126032</p>
+							<p>Rua da Escola Primária, Edifício Administrativo da Fundação Manuel Viegas Guerreiro, Querença, Loulé, 8100-129</p>
+							<p>Email: <a href="mailto:info@moces.pt" class="text-black hover:underline">info@moces.pt</a></p>
+						</div>
+					</section>
 				</div>
 			</section>
 


### PR DESCRIPTION
- Contacts card in the Terms & Conditions section now reads "Associação
  MÔÇES" (accented), matching the two privacy contact cards.
- Add a placeholder English "Terms & Conditions" section under the ENGLISH
  banner, ready to receive the client's English translation of the
  Portuguese termos section.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pwdf6WgkCBSidiLtT3qWD3